### PR TITLE
fix: different column names

### DIFF
--- a/db/users.sql
+++ b/db/users.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
     username VARCHAR(50) UNIQUE NOT NULL,
-    passwords VARCHAR(250) NOT NULL,
+    password VARCHAR(250) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
2024/07/14 09:51:04 Failed to preparex query: select u.id, u.username, u.password, w.id as wal let_id
        from public.users u
        JOIN public.wallets w
        ON u.id = w.user_id
        where u.username = $1. Error: pq: kolom u.password belum ada
exit status 1